### PR TITLE
Fix String from Nil error thrown when failed records

### DIFF
--- a/lib/clever_tap/successful_response.rb
+++ b/lib/clever_tap/successful_response.rb
@@ -29,7 +29,7 @@ class CleverTap
     end
 
     def success
-      errors.empty?
+      unprocessed.empty?
     end
   end
 end


### PR DESCRIPTION
Fixing an error we spotted in Sidekiq when trying to upload User with invalid phone number. The error says: 
`TypeError: no implicit conversion of nil into String`