### PR TITLE
Change gemspec before publishing to RubyGems.org

### DIFF
--- a/clever_tap.gemspec
+++ b/clever_tap.gemspec
@@ -5,7 +5,7 @@ require 'clever_tap/version'
 Gem::Specification.new do |spec|
   spec.name = 'clever_tap'
   spec.version = CleverTap::VERSION
-  spec.authors = ['Tradeo team']
+  spec.authors = ['Kamen Kanev', 'Svetoslav Blyahov']
   spec.email = ['opensource@tradeo.com']
   spec.license = 'MIT'
   spec.homepage = 'https://github.com/tradeo/clevertap-ruby'
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
+    spec.metadata['allowed_push_host'] = "https://rubygems.org"
   else
     raise 'RubyGems 2.0 or newer is required to protect against ' \
       'public gem pushes.'


### PR DESCRIPTION
Changing the `gemspec` file in order to be able to push the gem to `RubyGems.org`